### PR TITLE
README: update require for lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ augroup END
 
 ```lua
 local lspconfig = require 'lspconfig'
-local configs = require 'lspconfig/configs'
+local configs = require 'lspconfig.configs'
 
 if not configs.golangcilsp then
  	configs.golangcilsp = {


### PR DESCRIPTION
it seems that in newer versions lspconfig/configs does not work anymore in latest nvim versions, and lspconfig.configs must be used.

without this change, i got this error:
```
[Ensure this server is listed in `server_configurations.md` or added as a custom server.](https://old.reddit.com/r/neovim/comments/r8p0ye/lspconfig_ensure_this_server_is_listed_in_server/)
```